### PR TITLE
Set GC old/young ratio in spark-defaults.conf

### DIFF
--- a/templates/root/spark/conf/spark-defaults.conf
+++ b/templates/root/spark/conf/spark-defaults.conf
@@ -5,3 +5,4 @@ spark.continuousMonitor.logIntervalMillis 200
 spark.eventLog.enabled true
 spark.eventLog.dir file:///tmp/spark-events
 spark.shuffle.spill false
+spark.executor.extraJavaOptions -XX:NewRatio=1


### PR DESCRIPTION
By default, Java's garbage collector is configured so that the old
generation heap space is larger than the young generation heap space.
Since most objects are short-lived, this configuration is not ideal.
This commit adds the "-XX:NewRatio=1" Java option, which makes the young
region as large as possible (which is the same size as the old region).
